### PR TITLE
No process exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,6 @@ class HydraExpress {
     this.appLogger = defaultLogger();
     this.registeredPlugins = [];
     this.ready = Q.defer(); // Resolved when ready for work.
-    this.cleanedUp = Q.defer(); // Resolved when cleanup done and ready for process exit.
   }
 
   /**
@@ -343,10 +342,7 @@ class HydraExpress {
         cleanupDone = true;
         // Unsure about the arbitrary 1 second. - CH
         setTimeout(() => {
-          this._shutdown()
-          .finally(() => {
-            this.cleanedUp.resolve();
-          })
+          this._shutdown();
         }, 1000);
         // Safety handler to ensure we exit eventually.
         setTimeout(() => {
@@ -369,14 +365,6 @@ class HydraExpress {
         error: err.name,
         stack: stack
       }));
-      process.emit('cleanup');
-    });
-    process.on('SIGTERM', () => {
-      this.log('fatal', 'Received SIGTERM');
-      process.emit('cleanup');
-    });
-    process.on('SIGINT', () => {
-      this.log('fatal', 'Received SIGINT');
       process.emit('cleanup');
     });
 
@@ -443,13 +431,6 @@ class HydraExpress {
       }
     });
 
-    /**
-    * On SIGTERM perform graceful shutdown.
-    */
-    process.on('SIGTERM', () => {
-      this.log('error', `Process ${process.pid} recieved SIGTERM - attempting graceful shutdown`);
-      this.server.close();
-    });
 
     /**
      * @description listen handler for server.

--- a/index.js
+++ b/index.js
@@ -180,7 +180,10 @@ class HydraExpress {
   */
   _shutdown() {
     return new Promise((resolve, reject) => {
-      this.server.close(() => {
+      // A 1-second delay allows for active requests to finish before we kill the server.
+      // (A vanilla Hydra-express feature)
+      setTimeout(() => {
+        this.server.close(() => {
         this.log('error', 'Service is shutting down.');
         hydra.shutdown()
           .then((result) => {
@@ -189,7 +192,8 @@ class HydraExpress {
           .catch((err) => {
             reject(err);
           });
-      });
+        });
+      }, 1000);
     });
   }
 
@@ -340,10 +344,7 @@ class HydraExpress {
     process.on('cleanup', () => {
       if (!cleanupDone) {
         cleanupDone = true;
-        // Unsure about the arbitrary 1 second. - CH
-        setTimeout(() => {
-          this._shutdown();
-        }, 1000);
+        this._shutdown();
         // Safety handler to ensure we exit eventually.
         setTimeout(() => {
           process.exit();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-express",
-  "version": "1.9.5",
+  "version": "1.10.0",
   "description": "A module which wraps Hydra and ExpressJS to provide an out of the box microservice which can support API routes and handlers.",
   "author": {
     "name": "Carlos Justiniano"
@@ -10,12 +10,12 @@
     "test": "mocha specs --reporter spec"
   },
   "engines": {
-    "node": ">=6.2.1"
+    "node": "16.13.0"
   },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pnxtech/hydra-express.git"
+    "url": "git+https://github.com/pixelnebula/spark-hydra-express.git"
   },
   "bin": {
     "hydra-express": "index.js"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/pnxtech/hydra-express#readme",
   "dependencies": {
-    "bluebird": "3.7.2",
     "body-parser": "1.20.0",
     "cors": "2.8.5",
     "debug": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "helmet": "4.1.1",
     "hydra": "1.9.3",
     "moment": "2.29.3",
+    "q": "^1.5.1",
     "response-time": "2.3.2"
   },
   "devDependencies": {

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,12 @@
+Fixes #issuenumber
+
+### Summary of changes
+
+### Testing instructions
+
+### Pre-review checklist
+- [ ] Work fully resolves issue.
+- [ ] Code has been fully tested.
+- [ ] Code has been fully documented.
+- [ ] Package changes have been audited.
+- [ ] Package version has been increased following semver guidelines, or merging into patch branch.


### PR DESCRIPTION
### Summary of changes
- Removes the listeners for SIGINT/SIGTERM. Our shutdown call will instead be initiated by the [SC Ticketer](https://github.com/pixelnebula/spark-common/pull/199) in non-error circumstances.
- Removes Bluebird in favour of Q.
- Adds the ready promise and `start` method changes [removed from hydra-utils](https://github.com/pixelnebula/spark-common/pull/199).

### Pre-review checklist
- [x] Work fully resolves issue.
- [x] Code has been fully tested.
- [x] Code has been fully documented.
- [x] Package changes have been audited.
- [x] Package version has been increased following semver guidelines, or merging into patch branch.
